### PR TITLE
Recognise existence of 'Common' zone

### DIFF
--- a/custom_components/bonaire_myclimate/BonairePyClimate/bonairepyclimate.py
+++ b/custom_components/bonaire_myclimate/BonairePyClimate/bonairepyclimate.py
@@ -214,6 +214,10 @@ class BonairePyClimate():
             self._queueing_commands = False
 
     def get_zone_combinations(self, zoneList):
+        # Installations without multiple zones will have one "common" zone
+        if zoneList == 'Common':
+            return list('')
+            
         zoneList = zoneList.replace(',','')
         preset_modes = []
         for i in range(1, len(zoneList)+1):


### PR DESCRIPTION
Where there is only one 'zone', e.g. a system too small for actual zoning :(, the zoneList will be 'Common', which results in the HA presets being every combination of those characters, per the screenshot..

Installation response:
`2020-09-01 20:31:06 DEBUG (MainThread) [custom_components.bonaire_myclimate.BonairePyClimate.bonairepyclimate] Server data received: <myclimate><response>installation</response><appliance><type>heat</type><zoneList>Common</zoneList></appliance><appliance><type>cool</type><zoneList>Common</zoneList></appliance><appliance><type>evap</type><zoneList></zoneList></appliance><zoneName id="Common">Common</zoneName></myclimate>`

Presets with existing code:
![image](https://user-images.githubusercontent.com/3479092/91840844-affb0500-ec94-11ea-87f4-bc0db65312ac.png)

With the modified code, clicking preset does nothing.

I haven't tested extensively as I don't have a lot set up to use the integration as yet, but can't see how this would have too much in terms of unintended consequences.