### PR TITLE
fix: Update various deprecated constants. Support TURN_OFF

### DIFF
--- a/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
+++ b/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
@@ -3,10 +3,7 @@ import asyncio
 import logging
 import xml.etree.ElementTree
 
-from homeassistant.components.climate.const import (
-    HVAC_MODE_OFF, HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_FAN_ONLY,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE, SUPPORT_FAN_MODE,
-)
+from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
 
 from .helpers import (
     create_datagram_transport, create_server, zone_combinations
@@ -30,6 +27,7 @@ class Hub:
         self._appliances = {}
         self._callbacks = set()
         self._connected = False # When there is an open TCP connection
+        self._enable_turn_on_off_backwards_compatibility = False
         self._fan_mode_memory_heat = "thermo"
         self._postzoneinfo_response_ok = False
         self._queued_commands = []
@@ -49,7 +47,7 @@ class Hub:
         self.hvac_modes = None
         self.preset_mode = None
         self.preset_modes = None
-        self.supported_features = 0
+        self.supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF
         self.target_temperature = None
 
         self._start_task = self._hass.loop.create_task(self.async_start())
@@ -99,7 +97,6 @@ class Hub:
 
                 elif 5 <= attempts:
                     self.available = False
-                    self.supported_features = 0
                     await self.publish_updates()
                     _LOGGER.warning(f"Discovery attempt #{attempts} failed, retrying in {cooloff_timer}s")
                     await asyncio.sleep(cooloff_timer)
@@ -169,12 +166,12 @@ class Hub:
                 self._appliances[type] = zoneList
 
             # Build hvac_modes property
-            self.hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_FAN_ONLY]
+            self.hvac_modes = [HVACMode.OFF, HVACMode.FAN_ONLY]
             if self._appliances["heat"] is not None:
-                self.hvac_modes += [HVAC_MODE_HEAT]
+                self.hvac_modes += [HVACMode.HEAT]
             if (self._appliances["cool"] is not None or
                     self._appliances["evap"] is not None):
-                self.hvac_modes += [HVAC_MODE_COOL]
+                self.hvac_modes += [HVACMode.COOL]
 
             # Build the preset modes for each type of appliance
             self._preset_modes_heat = zone_combinations(
@@ -200,38 +197,37 @@ class Hub:
 
             # Process the zone info, build the hvac properties
             if self._zone_info["system"] == "off":
-                self.hvac_mode = HVAC_MODE_OFF
-                self.supported_features = 0
+                self.hvac_mode = HVACMode.OFF
             elif self._zone_info["mode"] == "fan":
                 self.fan_mode = self._zone_info["fanSpeed"]
                 self.fan_modes = FAN_MODES_FAN_ONLY
-                self.hvac_mode = HVAC_MODE_FAN_ONLY
+                self.hvac_mode = HVACMode.FAN_ONLY
                 if self._zone_info["type"] == "heat":
                     self.preset_modes = self._preset_modes_heat
                 else:
                     self.preset_modes = self._preset_modes_cool
-                self.supported_features = SUPPORT_PRESET_MODE | SUPPORT_FAN_MODE
+                self.supported_features = ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF
             elif self._zone_info["type"] == "heat":
                 self._fan_mode_memory_heat = self._zone_info["mode"]
                 self.fan_mode = self._zone_info["mode"]
                 self.fan_modes = FAN_MODES_HEAT
-                self.hvac_mode = HVAC_MODE_HEAT
+                self.hvac_mode = HVACMode.HEAT
                 self.preset_modes = self._preset_modes_heat
-                self.supported_features = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE | SUPPORT_FAN_MODE
+                self.supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF
                 self.target_temperature = int(self._zone_info["setPoint"])
             elif self._zone_info["type"] == "cool":
                 self.fan_mode = self._zone_info["mode"]
                 self.fan_modes = FAN_MODES_COOL
-                self.hvac_mode = HVAC_MODE_COOL
+                self.hvac_mode = HVACMode.COOL
                 self.preset_modes = self._preset_modes_cool
-                self.supported_features = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE | SUPPORT_FAN_MODE
+                self.supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF
                 self.target_temperature = int(self._zone_info["setPoint"])
             elif self._zone_info["type"] == "evap":
                 self.fan_mode = self._zone_info["fanSpeed"]
                 self.fan_modes = FAN_MODES_EVAP
-                self.hvac_mode = HVAC_MODE_COOL
+                self.hvac_mode = HVACMode.COOL
                 self.preset_modes = self._preset_modes_evap
-                self.supported_features = SUPPORT_PRESET_MODE | SUPPORT_FAN_MODE
+                self.supported_features = ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF
 
             self.current_temperature = int(self._zone_info["roomTemp"])
             self.preset_mode = self._zone_info["zoneList"]
@@ -272,22 +268,22 @@ class Hub:
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
-        if hvac_mode == HVAC_MODE_OFF:
+        if hvac_mode == HVACMode.OFF:
             commands = {
                 "system": "off"
             }
-        elif hvac_mode == HVAC_MODE_FAN_ONLY:
+        elif hvac_mode == HVACMode.FAN_ONLY:
             commands = {
                 "system": "on",
                 "mode": "fan"
             }
-        elif hvac_mode == HVAC_MODE_HEAT:
+        elif hvac_mode == HVACMode.HEAT:
             commands = {
                 "system": "on",
                 "type": "heat",
                 "mode": self._fan_mode_memory_heat
             }
-        elif hvac_mode == HVAC_MODE_COOL:
+        elif hvac_mode == HVACMode.COOL:
             if self._appliances["cool"] is not None:
                 commands = {
                     "system": "on",
@@ -301,6 +297,9 @@ class Hub:
                 }
 
         await self.async_send_commands(commands)
+
+    async def async_turn_off(self) -> None:
+        await self.async_set_hvac_mode(HVACMode.OFF)
 
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode."""

--- a/custom_components/bonaire_myclimate/climate.py
+++ b/custom_components/bonaire_myclimate/climate.py
@@ -5,7 +5,7 @@ from homeassistant.components.climate import (
     ClimateEntity,
 )
 from homeassistant.const import (
-    ATTR_TEMPERATURE, TEMP_CELSIUS,
+    ATTR_TEMPERATURE, UnitOfTemperature,
 )
 from .const import (
     DEVICE_MANUFACTURER, DEVICE_MODEL, DEVICE_NAME, DOMAIN,
@@ -133,7 +133,7 @@ class BonaireMyClimateClimate(ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     async def async_set_fan_mode(self, fan_mode):
         """Set new target fan operation."""

--- a/custom_components/bonaire_myclimate/climate.py
+++ b/custom_components/bonaire_myclimate/climate.py
@@ -143,6 +143,9 @@ class BonaireMyClimateClimate(ClimateEntity):
         """Set new target hvac mode."""
         await self._hub.async_set_hvac_mode(hvac_mode)
 
+    async def async_turn_off(self) -> None:
+        await self._hub.async_turn_off()
+
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode."""
         await self._hub.async_set_preset_mode(preset_mode)


### PR DESCRIPTION
I've updated a bunch of deprecated constants, and implemented an explicit TURN_OFF function, as detailed in https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/

My prompt for doing this was my call to the `climate.turn_off` service being broken. It's a winter automation so I haven't used it in several months.. I can't say exactly when it broke, but it's logical to assume it was in line with the above blog post.
I've run with these changes for a couple days now and it's gone well.

I haven't implemented `turn_on` because I'm not sure how you'd practically do that with this integration.

![image](https://github.com/bremor/bonaire_myclimate/assets/3479092/5009aad1-909c-4b16-a81b-98bcee9df974)

![image](https://github.com/bremor/bonaire_myclimate/assets/3479092/e7644042-5073-4ae9-8636-87b6edf20b6d)

Fixes https://github.com/bremor/bonaire_myclimate/issues/32, https://github.com/bremor/bonaire_myclimate/issues/31
