### PR TITLE
Replace async_foward_entry_setup with async_forward_entry_setups

### DIFF
--- a/custom_components/bonaire_myclimate/__init__.py
+++ b/custom_components/bonaire_myclimate/__init__.py
@@ -22,10 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     local_ip = await async_get_source_ip(hass)
     hass.data[DOMAIN][entry.entry_id] = hub.Hub(hass, local_ip)
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def send_raw_command(call):
         """Handle the service call."""


### PR DESCRIPTION
`Detected code that calls async_forward_entry_setup for integration <snip>, during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1. Please report this issue.`