### PR TITLE
fix: Evap Thermo Mode Support

### DIFF
--- a/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
+++ b/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
@@ -42,7 +42,6 @@ class Hub:
         self.available = False
         self.current_temperature = None
         self.fan_mode = None
-        self.evap_mode = None
         self.fan_modes = None
         self.hvac_mode = None
         self.hvac_modes = None
@@ -224,27 +223,27 @@ class Hub:
                 self.supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
                 self.target_temperature = int(self._zone_info["setPoint"])
             elif self._zone_info["type"] == "evap" and self._zone_info["mode"] == "thermo":
-                self.evap_mode = self._zone_info["mode"]
                 self.fan_mode = self._zone_info["setPoint"]
                 self.fan_modes = FAN_MODES_EVAP
                 self.hvac_mode = HVACMode.COOL
-                self.preset_modes = self._preset_modes_evap
+                self.preset_modes = ["thermo", "manual", "boost"]
                 self.supported_features = ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
             elif self._zone_info["type"] == "evap":
-                self.evap_mode = self._zone_info["mode"]
                 self.fan_mode = self._zone_info["fanSpeed"]
                 self.fan_modes = FAN_MODES_EVAP
                 self.hvac_mode = HVACMode.COOL
-                self.preset_modes = self._preset_modes_evap
+                self.preset_modes = ["thermo", "manual", "boost"]
                 self.supported_features = ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
 
             self.current_temperature = int(self._zone_info["roomTemp"])
-            self.preset_mode = self._zone_info["zoneList"]
+            if self._zone_info.get("type") == "evap":
+                self.preset_mode = self._zone_info["mode"]
+            else:
+                self.preset_mode = self._zone_info["zoneList"]
 
             self.available = True
             self._ready = True
             self._hass.loop.create_task(self.publish_updates())
-
 
         # Check if the message is postzoneinfo result 'ok'
         elif (root.findtext("response") == "postzoneinfo" and
@@ -266,7 +265,7 @@ class Hub:
             command = {"fanSpeed": fan_mode}
         elif self._zone_info["type"] == "evap" and self._zone_info["mode"] == "thermo":
             command = {"setPoint": fan_mode}
-            command["mode"] = "thermo"            
+            command["mode"] = "thermo"
         elif self._zone_info["type"] == "evap":
             command = {"fanSpeed": fan_mode}
             if int(fan_mode) < 8:
@@ -319,7 +318,10 @@ class Hub:
 
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode."""
-        command = {"zoneList": preset_mode}
+        if self._zone_info.get("type") == "evap":
+            command = {"type": "evap", "mode": preset_mode}
+        else:
+            command = {"zoneList": preset_mode}
         await self.async_send_commands(command)
 
     async def async_set_temperature(self, temperature):

--- a/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
+++ b/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
@@ -222,6 +222,12 @@ class Hub:
                 self.preset_modes = self._preset_modes_cool
                 self.supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
                 self.target_temperature = int(self._zone_info["setPoint"])
+            elif self._zone_info["type"] == "evap" and self._zone_info["mode"] == "thermo":
+                self.fan_mode = self._zone_info["setPoint"]
+                self.fan_modes = FAN_MODES_EVAP
+                self.hvac_mode = HVACMode.COOL
+                self.preset_modes = self._preset_modes_evap
+                self.supported_features = ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
             elif self._zone_info["type"] == "evap":
                 self.fan_mode = self._zone_info["fanSpeed"]
                 self.fan_modes = FAN_MODES_EVAP
@@ -255,6 +261,9 @@ class Hub:
         """Set new target fan operation."""
         if self._zone_info["mode"] == "fan":
             command = {"fanSpeed": fan_mode}
+        elif self._zone_info["type"] == "evap" and self._zone_info["mode"] == "thermo":
+            command = {"setPoint": fan_mode}
+            command["mode"] = "thermo"            
         elif self._zone_info["type"] == "evap":
             command = {"fanSpeed": fan_mode}
             if int(fan_mode) < 8:

--- a/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
+++ b/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
@@ -42,6 +42,7 @@ class Hub:
         self.available = False
         self.current_temperature = None
         self.fan_mode = None
+        self.evap_mode = None
         self.fan_modes = None
         self.hvac_mode = None
         self.hvac_modes = None
@@ -223,12 +224,14 @@ class Hub:
                 self.supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
                 self.target_temperature = int(self._zone_info["setPoint"])
             elif self._zone_info["type"] == "evap" and self._zone_info["mode"] == "thermo":
+                self.evap_mode = self._zone_info["mode"]
                 self.fan_mode = self._zone_info["setPoint"]
                 self.fan_modes = FAN_MODES_EVAP
                 self.hvac_mode = HVACMode.COOL
                 self.preset_modes = self._preset_modes_evap
                 self.supported_features = ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
             elif self._zone_info["type"] == "evap":
+                self.evap_mode = self._zone_info["mode"]
                 self.fan_mode = self._zone_info["fanSpeed"]
                 self.fan_modes = FAN_MODES_EVAP
                 self.hvac_mode = HVACMode.COOL

--- a/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
+++ b/custom_components/bonaire_myclimate/BonairePyClimate/hub.py
@@ -29,6 +29,7 @@ class Hub:
         self._connected = False # When there is an open TCP connection
         self._enable_turn_on_off_backwards_compatibility = False
         self._fan_mode_memory_heat = "thermo"
+        self._fan_mode_memory_evap = "manual"
         self._postzoneinfo_response_ok = False
         self._queued_commands = []
         self._ready = False # Ready to send commands
@@ -223,12 +224,14 @@ class Hub:
                 self.supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
                 self.target_temperature = int(self._zone_info["setPoint"])
             elif self._zone_info["type"] == "evap" and self._zone_info["mode"] == "thermo":
+                self._fan_mode_memory_evap = "thermo"
                 self.fan_mode = self._zone_info["setPoint"]
                 self.fan_modes = FAN_MODES_EVAP
                 self.hvac_mode = HVACMode.COOL
                 self.preset_modes = ["thermo", "manual", "boost"]
                 self.supported_features = ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
             elif self._zone_info["type"] == "evap":
+                self._fan_mode_memory_evap = self._zone_info["mode"]
                 self.fan_mode = self._zone_info["fanSpeed"]
                 self.fan_modes = FAN_MODES_EVAP
                 self.hvac_mode = HVACMode.COOL
@@ -304,7 +307,8 @@ class Hub:
             elif self._appliances["evap"] is not None:
                 commands = {
                     "system": "on",
-                    "type": "evap"
+                    "type": "evap",
+                    "mode": self._fan_mode_memory_evap
                 }
 
         await self.async_send_commands(commands)

--- a/custom_components/bonaire_myclimate/climate.py
+++ b/custom_components/bonaire_myclimate/climate.py
@@ -126,13 +126,6 @@ class BonaireMyClimateClimate(ClimateEntity):
         return self._hub.target_temperature
     
     @property
-    def extra_state_attributes(self):
-        """Return extra state attributes."""
-        if self._hub.evap_mode is not None:
-            return {"evap_mode": self._hub.evap_mode}
-        return {}
-
-    @property
     def target_temperature_step(self):
         """Return the supported step of target temperature."""
         return TEMPERATURE_STEP

--- a/custom_components/bonaire_myclimate/climate.py
+++ b/custom_components/bonaire_myclimate/climate.py
@@ -124,6 +124,13 @@ class BonaireMyClimateClimate(ClimateEntity):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         return self._hub.target_temperature
+    
+    @property
+    def extra_state_attributes(self):
+        """Return extra state attributes."""
+        if self._hub.evap_mode is not None:
+            return {"evap_mode": self._hub.evap_mode}
+        return {}
 
     @property
     def target_temperature_step(self):


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax; please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `

  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What this PR does / why we need it:

Traceback key error would occur when running my evaporative cooler in Thermo mode.  Thermo mode uses setpoint for fanspeed rather than the fanspeed key.

This update adds check if the system is and Evap and Thermo mode it will send the fanspeed as setpoint instead of fanspeed.

I've kept the code consistent with the coding for the other modes of the Bonaire MyClimate system.

<!--
  What goal is this change working towards?
  Briefly explain any decisions you made with respect to the changes.
-->

## Which issue(s) this PR fixes:

None - as I didn't put in an issues - I just forked the repo and figured out the fix myself.

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39

If it doesn't fix any issues, please say None
-->

## Special notes for your reviewer:

I had a previous pull request in but it got out of sync when boc-the-git updated the bremor repo.  I have redone the changes with the latest bremor commit as the starting point, additions are minimal and won't affect other parts of the code.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

I have tested this version on my own HA setup.  My Bonaire system consists of Gas Heater with Common + 2 zones.  Evaporative cooler that obviously has the thermo feature.

I have tested the code by testing heater operation and it's zone control and then testing the Evaporative cooling operation and ensure no errors occur when in thermo mode.  I changed the evap cooling modes use the send_raw_command action - 

            - service: bonaire_myclimate.send_raw_command
                            data:
                                    raw_command:
                                      type: "evap"
                                      mode: "thermo"     


              - service: bonaire_myclimate.send_raw_command
                data:
                        raw_command:
                          type: "evap"
                          mode: "manual"
    

              - service: bonaire_myclimate.send_raw_command
                data:
                        raw_command:
                          type: "evap"
                          mode: "boost"

I tested adjusting the fan speed while in thermo mode and in manual from home assistant.

I also tested changing the modes on the Navigator controller to ensure home assistant got these changes.

The basic changes have been running problem free for me since I initially did them year or 2 ago - this commit is just new but fundamentally the same additions to the bremor code as my first iteration of it. 
<!--
  Describe how you tested this change.
-->
